### PR TITLE
migrate api for getting the avatar

### DIFF
--- a/services/avatar.py
+++ b/services/avatar.py
@@ -148,7 +148,8 @@ async def _get_avatar_url_from_web_coroutine(user_id, future):
 async def _do_get_avatar_url_from_web(user_id):
     try:
         async with utils.request.http_session.get(
-            'https://api.bilibili.com/x/space/acc/info',
+            # 'https://api.bilibili.com/x/space/acc/info',
+            'https://api.bilibili.com/x/space/app/index',
             headers={
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)'
                               ' Chrome/102.0.0.0 Safari/537.36'
@@ -168,7 +169,8 @@ async def _do_get_avatar_url_from_web(user_id):
     except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
         return None
 
-    avatar_url = process_avatar_url(data['data']['face'])
+    # avatar_url = process_avatar_url(data['data']['face'])
+    avatar_url = process_avatar_url(data['data']['info']['face'])
     update_avatar_cache(user_id, avatar_url)
     return avatar_url
 

--- a/services/avatar.py
+++ b/services/avatar.py
@@ -162,7 +162,7 @@ async def _do_get_avatar_url_from_web_original(uid):
         f'https://chat.bilisc.com/api/avatar_url',
         {'uid':uid},
         uid,
-        no_json = True,
+        no_json = False,
     )
     if _data is None:
         return None

--- a/services/avatar.py
+++ b/services/avatar.py
@@ -252,6 +252,7 @@ async def _do_async_get(url: str, params: dict, user_id, no_json):
             url,
             headers={
                 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Mobile Safari/537.36',
+                'cookie': '',
                 'sec-ch-ua-mobile': '?1',
                 'sec-ch-ua-platform': "Android",
             },

--- a/services/avatar.py
+++ b/services/avatar.py
@@ -157,6 +157,23 @@ async def _do_get_avatar_url_from_web(user_id):
     return avatar_url
 
 
+async def _do_get_avatar_url_from_web_original(uid):
+    _data = await _do_async_get(
+        f'https://chat.bilisc.com/api/avatar_url',
+        {'uid':uid},
+        uid,
+        no_json = True,
+    )
+    if _data is None:
+        return None
+    avatar_url = None
+    try:
+        avatar_url = _data['avatarUrl']
+    except Exception:
+        return None
+    finally:
+        return avatar_url
+
 async def _do_get_avatar_url_from_web_space(mid):
     _data = await _do_async_get(
         f'https://m.bilibili.com/space/{mid}',
@@ -300,6 +317,7 @@ def _update_avatar_cache_in_database(user_id, avatar_url):
 
 # 用来请求头像的函数列表
 AVATAR_API_FUNC = [
+    _do_get_avatar_url_from_web_original,
     _do_get_avatar_url_from_web_space,
     _do_get_avatar_url_from_web_interface,
     _do_get_avatar_url_from_web_app,


### PR DESCRIPTION
# 原有的api被反爬虫拦截

我将原本的
https://api.bilibili.com/x/space/acc/info
修改到了
https://api.bilibili.com/x/space/app/index

这个api返回了太多用不到的数据，可能会在大量请求新头像的时候比原来卡顿，但是在彻底解决反爬虫问题之前可以先将就用着

## 附上原api的返回值(已去除敏感数据)
```json
{
    "code": -401,
    "message": "非法访问",
    "ttl": 1,
    "data": {
        "ga_data": {
            "decisions": [
                "verify_captcha_level2"
            ],
            "risk_level": 1,
            "grisk_id": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
            "decision_ctx": {
                "buvid": "",
                "ip": "XXX.XXX.XXX.XXX",
                "mid": "0",
                "scene": "anti_crawler",
                "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36",
                "v_voucher": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
            }
        }
    }
}
```
