### PR TITLE
fix: 修复一定时间后弹幕的用户名头像打码

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -284,6 +284,47 @@ class ChatHandler(tornado.websocket.WebSocketHandler):  # noqa
         gift_data['giftName'] = '小电视飞船'
         self.send_cmd_data(Command.ADD_GIFT, gift_data)
 
+class DanmuInfoHandler(api.base.ApiHandler): # noqa # 获取房间的token(作为key)，以及host_list
+    async def get(self):
+        room_id = int(self.get_query_argument('roomId'))
+        logger.info('client=%s getting danmu info, room=%d', self.request.remote_ip, room_id)
+        danmu_info = await self._get_danmu_info(room_id)
+        data = {}
+        if danmu_info != None:
+            data['token'] = danmu_info['token']
+            data['hostServerList'] = danmu_info['host_list']
+        self.write(data)
+
+    @staticmethod
+    async def _get_danmu_info(room_id):
+        try:
+            async with utils.request.http_session.get(
+                blivedm_client.DANMAKU_SERVER_CONF_URL,
+                headers={
+                    **utils.request.BILIBILI_COMMON_HEADERS,
+                    'Origin': 'https://live.bilibili.com',
+                    'Referer': f'https://live.bilibili.com/{room_id}'
+                },
+                cookies=utils.request.BILIBILI_COMMON_COOKIES,
+                params={
+                    'id': room_id
+                }
+            ) as res:
+                if res.status != 200:
+                    logger.warning('room=%d _get_danmu_info failed: %d %s', room_id,
+                                   res.status, res.reason)
+                    return None
+                data = await res.json()
+        except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
+            logger.exception('room=%d _get_danmu_info failed', room_id)
+            return None
+
+        if data['code'] != 0:
+            logger.warning('room=%d _get_danmu_info failed: %s', room_id, data['message'])
+            return None
+
+        return data['data']
+
 
 class RoomInfoHandler(api.base.ApiHandler):  # noqa
     async def get(self):

--- a/frontend/src/api/chat/ChatClientDirect/index.js
+++ b/frontend/src/api/chat/ChatClientDirect/index.js
@@ -111,7 +111,7 @@ export default class ChatClientDirect {
       uid: 0,
       roomid: this.roomId,
       protover: 3,
-      platform: 'web',
+      platform: 'danmuji',
       type: 2
     }
     this.websocket.send(this.makePacket(authParams, OP_AUTH))

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ routes = [
     (r'/api/server_info', api.main.ServerInfoHandler),
     (r'/api/chat', api.chat.ChatHandler),
     (r'/api/room_info', api.chat.RoomInfoHandler),
+    (r'/api/danmu_info', api.chat.DanmuInfoHandler),
     (r'/api/avatar_url', api.chat.AvatarHandler),
 
     (rf'{api.main.EMOTICON_BASE_URL}/(.*)', tornado.web.StaticFileHandler, {'path': api.main.EMOTICON_UPLOAD_PATH}),


### PR DESCRIPTION
根据 [弹幕姬](https://github.com/copyliu/bililive_dm/) 的认证步骤，将相应行的 platform 从 'web' 更改为 'danmuji' 后，挂机一小时后发现已经没有打码的现象。
另外 弹幕姬 内的认证步骤存在的 key 和 host_list 的获取也有在该项目尝试，但似乎只修改 platform 即可避免打码。

没有经过更长时间的测试，请酌情考虑。