### PR TITLE
修复表情包以及一个小问题

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -105,7 +105,7 @@ def make_text_message_data(
         # 15: textEmoticons
         [],  # 已废弃，保留
         # 16: authorId
-        author_id
+        uid
     ]
 
 

--- a/api/chat.py
+++ b/api/chat.py
@@ -104,7 +104,7 @@ def make_text_message_data(
         content_type_params if content_type_params is not None else [],
         # 15: textEmoticons
         [],  # 已废弃，保留
-        # 16: authorId
+        # 16: uid
         uid
     ]
 

--- a/frontend/src/views/Room.vue
+++ b/frontend/src/views/Room.vue
@@ -934,6 +934,9 @@ export default {
             // 只能区分是否是用户自己购买的表情
             richContent.push(this.generateEmoticonData(constants.CONTENT_TYPE_EMOTICON, data.content, `room-${data.content}`, data.emoticon, 64))
             return richContent
+          } else {
+            richContent.push(this.generateEmoticonData(constants.CONTENT_TYPE_EMOTICON, data.content, `other-${data.content}`, data.emoticon, 64))
+            return richContent
           }
         }
       }


### PR DESCRIPTION
开放平台的表情包链接会是https，并且不符合代码中的情况判断，导致表情不显示，增加一个保底处理。
```python
{'emoji_img_url': 'https://i0.hdslb.com/bfs/garb/4b275cb1db4bec89fcaa281a3fd5a75945631207.png', 'fans_medal_level': 8, 'fans_medal_name': '风铃当', 'fans_medal_wearing_status': False, 'guard_level': 0, 'msg': '[鲸落
落raku_你的]', 'timestamp': 1695646217, 'uid': 2305653, 'uname': '铃当Reito', 'uface': 'https://i0.hdslb.com/bfs/face/a92765b4f6e0c0c77f225106ff25e1e6934111e9.jpg', 'dm_type': 1, 'msg_id': '6e663f00-6d22-48c9-b0a6-685624d009aa', 'room_id': 6239128}
```

以及一个昨天引入的小bug， author_id重命名时漏掉改为uid导致转发模式会出问题